### PR TITLE
TypeFix for later Version and .Net 6

### DIFF
--- a/src/Services/Ordering/Ordering.Application/Behaviours/UnhandledExceptionBehaviour.cs
+++ b/src/Services/Ordering/Ordering.Application/Behaviours/UnhandledExceptionBehaviour.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Ordering.Application.Behaviours
 {
-    public class UnhandledExceptionBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    public class UnhandledExceptionBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
     {
         private readonly ILogger<TRequest> _logger;
 


### PR DESCRIPTION
on later version, It won't build without declaring the Type

<img width="566" alt="image" src="https://user-images.githubusercontent.com/64571779/153718880-41714a4c-e0bf-4741-b994-30b58d37a3b2.png">

after type 

<img width="543" alt="image" src="https://user-images.githubusercontent.com/64571779/153718924-29097ddd-060d-4ae8-a0bf-8df5d75832c9.png">
