### PR TITLE
fix #90 added limitation on zipcode input

### DIFF
--- a/src/WebApps/Shopping.Web/Pages/Checkout.cshtml
+++ b/src/WebApps/Shopping.Web/Pages/Checkout.cshtml
@@ -130,7 +130,7 @@
                     </div>
                     <div class="col-md-3 mb-3">
                         <label asp-for="Order.ZipCode" for="zip">Zip</label>
-                        <input asp-for="Order.ZipCode" type="text" class="form-control" id="zip" placeholder="" required>
+                        <input asp-for="Order.ZipCode" type="text" class="form-control" id="zip" placeholder="" maxlength="5" required>
                         <div class="invalid-feedback">
                             Zip code required.
                         </div>


### PR DESCRIPTION
In order to not change the scope of the project, I added a small change of maximum size to the frontend zipcode input.

I added this item because it doesn't change the project too much, but it helps people who are starting the project and may be confused about whether the order api is working or not.

It was a feeling I had when sending a zipcode that generates the exception, because in my country zipcodes are 8 characters long.